### PR TITLE
Add Ruby 4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.3']
+        ruby: ['3.2', '3.3', '4.0']
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspock (2.0.0)
+    rspock (2.1.0)
       ast_transform (~> 2.0)
       minitest (~> 5.0)
       mocha (>= 1.0)

--- a/lib/rspock/version.rb
+++ b/lib/rspock/version.rb
@@ -1,3 +1,3 @@
 module RSpock
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
## Summary

- Add Ruby 4.0 to CI matrix (3.2, 3.3, 4.0)
- Bump version to 2.1.0
- Ruby 4.0 support is inherited from ast-transform v2.1.0 (rspockframework/ast-transform#9) which switches to `Prism::Translation::Parser`
- No code changes needed in rspock itself -- it uses `Parser::AST::Node` (not `CurrentRuby`) and gets the parser swap through its ast-transform dependency

## Test plan

- [x] All 129 tests pass on Ruby 3.3
- [x] All 129 tests pass on Ruby 4.0
- [x] CI passes on Ruby 3.2, 3.3, 4.0

Made with [Cursor](https://cursor.com)