### PR TITLE
feat: add >> raises(...) for exception stubbing in interactions

### DIFF
--- a/lib/rspock/ast/node.rb
+++ b/lib/rspock/ast/node.rb
@@ -70,6 +70,17 @@ module RSpock
       end
     end
 
+    class OutcomeNode < Node
+    end
+
+    class ReturnsNode < OutcomeNode
+      register :rspock_returns
+    end
+
+    class RaisesNode < OutcomeNode
+      register :rspock_raises
+    end
+
     class InteractionNode < Node
       register :rspock_interaction
 
@@ -78,7 +89,7 @@ module RSpock
       def message_sym  = children[2]
       def message      = message_sym.children[0]
       def args         = children[3]
-      def return_value = children[4]
+      def outcome      = children[4]
       def block_pass   = children[5]
     end
 

--- a/test/rspock/ast/interaction_to_mocha_mock_transformation_test.rb
+++ b/test/rspock/ast/interaction_to_mocha_mock_transformation_test.rb
@@ -154,6 +154,41 @@ module RSpock
         refute_match(/returns/, result)
       end
 
+      test ">> raises(ExClass) stubs exception" do
+        assert_transforms(
+          '1 * receiver.message >> raises(SomeError)',
+          'receiver.expects(:message).times(1).raises(SomeError)'
+        )
+      end
+
+      test ">> raises(ExClass, message) stubs exception with message" do
+        assert_transforms(
+          '1 * receiver.message >> raises(SomeError, "oops")',
+          'receiver.expects(:message).times(1).raises(SomeError, "oops")'
+        )
+      end
+
+      test ">> raises(ExClass.new(msg)) stubs exception instance" do
+        assert_transforms(
+          '1 * receiver.message >> raises(SomeError.new("oops"))',
+          'receiver.expects(:message).times(1).raises(SomeError.new("oops"))'
+        )
+      end
+
+      test ">> raises with params and cardinality" do
+        assert_transforms(
+          '1 * receiver.message(param1, param2) >> raises(SomeError)',
+          'receiver.expects(:message).with(param1, param2).times(1).raises(SomeError)'
+        )
+      end
+
+      test ">> raises with range cardinality" do
+        assert_transforms(
+          '(1..3) * receiver.message >> raises(SomeError)',
+          'receiver.expects(:message).at_least(1).at_most(3).raises(SomeError)'
+        )
+      end
+
       test "&block produces setup with expects and capture" do
         ir_node = parse_to_ir('1 * receiver.message("arg", &my_proc)')
         result = @transformation.run(ir_node)

--- a/test/rspock/ast/parser/interaction_parser_test.rb
+++ b/test/rspock/ast/parser/interaction_parser_test.rb
@@ -115,16 +115,31 @@ module RSpock
           assert_equal 2, args.children.length
         end
 
-        # --- parse: return value ---
+        # --- parse: outcome ---
 
-        test "#parse sets return_value to nil without >>" do
+        test "#parse sets outcome to nil without >>" do
           ir = parse('1 * receiver.message')
-          assert_nil ir.children[4]
+          assert_nil ir.outcome
         end
 
-        test "#parse extracts return value from >>" do
+        test "#parse wraps >> value in :rspock_returns" do
           ir = parse('1 * receiver.message >> "result"')
-          assert_equal s(:str, "result"), ir.children[4]
+          assert_equal :rspock_returns, ir.outcome.type
+          assert_equal s(:str, "result"), ir.outcome.children[0]
+        end
+
+        test "#parse wraps >> raises(ExClass) in :rspock_raises" do
+          ir = parse('1 * receiver.message >> raises(SomeError)')
+          assert_equal :rspock_raises, ir.outcome.type
+          assert_equal :const, ir.outcome.children[0].type
+        end
+
+        test "#parse wraps >> raises(ExClass, msg) in :rspock_raises with two children" do
+          ir = parse('1 * receiver.message >> raises(SomeError, "oops")')
+          assert_equal :rspock_raises, ir.outcome.type
+          assert_equal 2, ir.outcome.children.length
+          assert_equal :const, ir.outcome.children[0].type
+          assert_equal s(:str, "oops"), ir.outcome.children[1]
         end
 
         # --- parse: block pass ---

--- a/test/rspock/ast/parser/then_block_test.rb
+++ b/test/rspock/ast/parser/then_block_test.rb
@@ -108,7 +108,7 @@ module RSpock
           assert_equal :block_pass, block_pass.type
         end
 
-        test "#to_rspock_node parses interaction with >> return value" do
+        test "#to_rspock_node parses interaction with >> outcome" do
           node = @transformer.build_ast('1 * receiver.message >> "result"')
           @block << node
 
@@ -117,9 +117,9 @@ module RSpock
 
           assert_equal :rspock_interaction, interaction.type
 
-          return_value = interaction.children[4]
-          refute_nil return_value
-          assert_equal :str, return_value.type
+          outcome = interaction.outcome
+          refute_nil outcome
+          assert_equal :rspock_returns, outcome.type
         end
 
         test "#to_rspock_node handles mixed interaction and comparison nodes" do


### PR DESCRIPTION
## Summary

- Introduces the **outcome** concept to interactions, replacing the raw `return_value` field. The `>>` operator now produces a typed outcome node (`:rspock_returns` or `:rspock_raises`) at parse time.
- The transformation generically forwards the outcome type and args to Mocha via an explicit `OUTCOME_METHODS` mapping — no branching or string manipulation.
- Adds `OutcomeNode`, `ReturnsNode`, and `RaisesNode` to the node type hierarchy for consistency with other RSpock node types.

### New syntax

```ruby
# Stub an exception
1 * repository.find(42) >> raises(RecordNotFound)

# With message
1 * repository.find(42) >> raises(RecordNotFound, "not found")

# With instance
1 * repository.find(42) >> raises(RecordNotFound.new("not found"))
```

### Files changed

- `lib/rspock/ast/parser/interaction_parser.rb` — `parse_outcome` wraps `>>` values in typed nodes
- `lib/rspock/ast/node.rb` — `OutcomeNode` / `ReturnsNode` / `RaisesNode`; `InteractionNode#outcome` replaces `#return_value`
- `lib/rspock/ast/interaction_to_mocha_mock_transformation.rb` — generic outcome forwarding via `OUTCOME_METHODS` constant
- `README.md` — new "Stubbing Exceptions" section, updated interaction anatomy diagram
- Tests updated and new tests added for all `raises` variants

## Test plan

- [x] All 189 existing tests pass (no regressions)
- [x] New parser tests: `>> raises(Ex)`, `>> raises(Ex, msg)` produce correct `:rspock_raises` nodes
- [x] New transformation tests: `raises(Ex)`, `raises(Ex, msg)`, `raises(Ex.new(msg))`, with params, with range cardinality


Made with [Cursor](https://cursor.com)