### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-02-28
+
 ### Added
 
 - Spock-style implicit assertions: every non-assignment statement in Then/Expect blocks is now an assertion — no assertion API needed.
@@ -138,7 +140,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/rspockframework/rspock/compare/v2.3.1...HEAD
+[Unreleased]: https://github.com/rspockframework/rspock/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/rspockframework/rspock/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/rspockframework/rspock/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/rspockframework/rspock/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/rspockframework/rspock/compare/v2.1.0...v2.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspock (2.3.1)
+    rspock (2.4.0)
       ast_transform (~> 2.0)
       minitest (~> 5.0)
       mocha (>= 1.0)

--- a/lib/rspock/version.rb
+++ b/lib/rspock/version.rb
@@ -1,3 +1,3 @@
 module RSpock
-  VERSION = "2.3.1"
+  VERSION = "2.4.0"
 end


### PR DESCRIPTION
## Summary

- Bump version to 2.4.0
- Move `[Unreleased]` CHANGELOG entries to `[2.4.0] - 2026-02-28`
- Regenerate `Gemfile.lock`

After merge, tag `v2.4.0` on master to trigger the release workflow.

Made with [Cursor](https://cursor.com)