### PR TITLE
Add raises assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Exception conditions: `raises ExceptionClass` in Then blocks wraps the preceding When block in an exception assertion.
+- Exception capture: `e = raises ExceptionClass` captures the exception for further assertions in the same Then block.
+- Exception conditions work with data-driven `Where` blocks.
+
+### Changed
+
+- Renamed interaction outcome nodes from `rspock_returns` / `rspock_raises` to `rspock_stub_returns` / `rspock_stub_raises` to distinguish them from the new exception condition `rspock_raises`.
+
 ## [2.4.0] - 2026-02-28
 
 ### Added

--- a/lib/rspock/ast/interaction_to_mocha_mock_transformation.rb
+++ b/lib/rspock/ast/interaction_to_mocha_mock_transformation.rb
@@ -10,14 +10,14 @@ module RSpock
     # Output: receiver.expects(:message).with(*args).times(n).returns(value)
     #
     # The outcome node type maps directly to the Mocha chain method:
-    #   :rspock_returns -> .returns(value)
-    #   :rspock_raises  -> .raises(exception_class, ...)
+    #   :rspock_stub_returns -> .returns(value)
+    #   :rspock_stub_raises  -> .raises(exception_class, ...)
     #
     # When block_pass is present, wraps the expects chain with a BlockCapture.capture call.
     class InteractionToMochaMockTransformation < ASTTransform::AbstractTransformation
       OUTCOME_METHODS = {
-        rspock_returns: :returns,
-        rspock_raises: :raises,
+        rspock_stub_returns: :returns,
+        rspock_stub_raises: :raises,
       }.freeze
 
       def initialize(index = 0)

--- a/lib/rspock/ast/node.rb
+++ b/lib/rspock/ast/node.rb
@@ -73,12 +73,20 @@ module RSpock
     class OutcomeNode < Node
     end
 
-    class ReturnsNode < OutcomeNode
-      register :rspock_returns
+    class StubReturnsNode < OutcomeNode
+      register :rspock_stub_returns
     end
 
-    class RaisesNode < OutcomeNode
+    class StubRaisesNode < OutcomeNode
+      register :rspock_stub_raises
+    end
+
+    class RaisesNode < Node
       register :rspock_raises
+
+      def exception_class = children[0]
+      def capture_var     = children[1]
+      def capture_name    = capture_var&.children&.[](0)
     end
 
     class InteractionNode < Node

--- a/lib/rspock/ast/parser/expect_block.rb
+++ b/lib/rspock/ast/parser/expect_block.rb
@@ -25,6 +25,11 @@ module RSpock
         def to_rspock_node
           statement_parser = StatementParser.new
           spock_children = @children.map { |child| statement_parser.parse(child) }
+
+          if spock_children.any? { |c| c.type == :rspock_raises }
+            raise BlockError, "raises() is not supported in Expect blocks @ #{range}. Use a When + Then block instead."
+          end
+
           s(:rspock_expect, *spock_children)
         end
       end

--- a/lib/rspock/ast/parser/interaction_parser.rb
+++ b/lib/rspock/ast/parser/interaction_parser.rb
@@ -14,7 +14,7 @@ module RSpock
       #   [1] receiver     - e.g. s(:send, nil, :subscriber)
       #   [2] message      - e.g. s(:sym, :receive)
       #   [3] args         - nil if no args, s(:array, *arg_nodes) otherwise
-      #   [4] outcome      - nil if no >>, otherwise s(:rspock_returns, value) or s(:rspock_raises, *args)
+      #   [4] outcome      - nil if no >>, otherwise s(:rspock_stub_returns, value) or s(:rspock_stub_raises, *args)
       #   [5] block_pass   - nil if no &, otherwise s(:block_pass, ...)
       class InteractionParser
         include RSpock::AST::NodeBuilder
@@ -63,9 +63,9 @@ module RSpock
 
         def parse_outcome(node)
           if node.type == :send && node.children[0].nil? && node.children[1] == :raises
-            s(:rspock_raises, *node.children[2..])
+            s(:rspock_stub_raises, *node.children[2..])
           else
-            s(:rspock_returns, node)
+            s(:rspock_stub_returns, node)
           end
         end
 

--- a/lib/rspock/ast/parser/then_block.rb
+++ b/lib/rspock/ast/parser/then_block.rb
@@ -30,6 +30,11 @@ module RSpock
             statement_parser.parse(child)
           end
 
+          raises_count = spock_children.count { |c| c.type == :rspock_raises }
+          if raises_count > 1
+            raise BlockError, "Then block @ #{range} may contain at most one raises() condition"
+          end
+
           s(:rspock_then, *spock_children)
         end
       end

--- a/test/example_rspock_test.rb
+++ b/test/example_rspock_test.rb
@@ -123,6 +123,44 @@ class ExampleRSpockTest < Minitest::Test
     result == "item"
   end
 
+  # --- Raises conditions ---
+
+  test "raises catches expected exception" do
+    Given
+    stack = []
+
+    When
+    stack.fetch(99)
+
+    Then
+    raises IndexError
+  end
+
+  test "raises with capture allows property assertions" do
+    Given
+    stack = []
+
+    When
+    stack.fetch(99)
+
+    Then
+    e = raises IndexError
+    e.message =~ /index 99/
+  end
+
+  test "raises with Where block for #{error_class}" do
+    When
+    Integer(input)
+
+    Then
+    raises error_class
+
+    Where
+    input   | error_class
+    "abc"   | ArgumentError
+    "hello" | ArgumentError
+  end
+
   test "interactions" do
     Given
     dep = mock

--- a/test/rspock/ast/parser/expect_block_test.rb
+++ b/test/rspock/ast/parser/expect_block_test.rb
@@ -41,6 +41,15 @@ module RSpock
           assert_equal [comparison], actual
         end
 
+        test "#to_rspock_node raises error when raises() is used" do
+          @transformer = ASTTransform::Transformer.new
+          @block << @transformer.build_ast('raises EmptyStackError')
+
+          assert_raises BlockError do
+            @block.to_rspock_node
+          end
+        end
+
         test "#to_rspock_node returns :rspock_expect node with statement children" do
           @block << s(:send, 1, :==, 2)
           @block << s(:send, 1, :!=, 2)

--- a/test/rspock/ast/parser/interaction_parser_test.rb
+++ b/test/rspock/ast/parser/interaction_parser_test.rb
@@ -122,21 +122,21 @@ module RSpock
           assert_nil ir.outcome
         end
 
-        test "#parse wraps >> value in :rspock_returns" do
+        test "#parse wraps >> value in :rspock_stub_returns" do
           ir = parse('1 * receiver.message >> "result"')
-          assert_equal :rspock_returns, ir.outcome.type
+          assert_equal :rspock_stub_returns, ir.outcome.type
           assert_equal s(:str, "result"), ir.outcome.children[0]
         end
 
-        test "#parse wraps >> raises(ExClass) in :rspock_raises" do
+        test "#parse wraps >> raises(ExClass) in :rspock_stub_raises" do
           ir = parse('1 * receiver.message >> raises(SomeError)')
-          assert_equal :rspock_raises, ir.outcome.type
+          assert_equal :rspock_stub_raises, ir.outcome.type
           assert_equal :const, ir.outcome.children[0].type
         end
 
-        test "#parse wraps >> raises(ExClass, msg) in :rspock_raises with two children" do
+        test "#parse wraps >> raises(ExClass, msg) in :rspock_stub_raises with two children" do
           ir = parse('1 * receiver.message >> raises(SomeError, "oops")')
-          assert_equal :rspock_raises, ir.outcome.type
+          assert_equal :rspock_stub_raises, ir.outcome.type
           assert_equal 2, ir.outcome.children.length
           assert_equal :const, ir.outcome.children[0].type
           assert_equal s(:str, "oops"), ir.outcome.children[1]

--- a/test/rspock/ast/parser/statement_parser_test.rb
+++ b/test/rspock/ast/parser/statement_parser_test.rb
@@ -171,6 +171,41 @@ module RSpock
           assert_equal :rspock_statement, result.type
         end
 
+        # --- Raises condition ---
+
+        test "#parse wraps raises(ExClass) in :rspock_raises" do
+          ast = build_ast('raises EmptyStackError')
+          result = @parser.parse(ast)
+
+          assert_equal :rspock_raises, result.type
+          assert_equal s(:const, nil, :EmptyStackError), result.exception_class
+          assert_nil result.capture_var
+        end
+
+        test "#parse wraps e = raises(ExClass) in :rspock_raises with capture_var" do
+          ast = build_ast('e = raises EmptyStackError')
+          result = @parser.parse(ast)
+
+          assert_equal :rspock_raises, result.type
+          assert_equal s(:const, nil, :EmptyStackError), result.exception_class
+          assert_equal s(:sym, :e), result.capture_var
+          assert_equal :e, result.capture_name
+        end
+
+        test "#parse does not treat regular assignment as raises condition" do
+          ast = build_ast('x = 1')
+          result = @parser.parse(ast)
+
+          assert_equal :lvasgn, result.type
+        end
+
+        test "#parse does not treat receiver.raises as raises condition" do
+          ast = build_ast('obj.raises')
+          result = @parser.parse(ast)
+
+          assert_equal :rspock_statement, result.type
+        end
+
         # --- Does not classify non-binary sends as binary ---
 
         test "#parse does not treat method call with args as binary statement" do

--- a/test/rspock/ast/parser/then_block_test.rb
+++ b/test/rspock/ast/parser/then_block_test.rb
@@ -122,7 +122,7 @@ module RSpock
 
           outcome = interaction.outcome
           refute_nil outcome
-          assert_equal :rspock_returns, outcome.type
+          assert_equal :rspock_stub_returns, outcome.type
         end
 
         test "#to_rspock_node handles mixed interaction and comparison nodes" do
@@ -134,6 +134,25 @@ module RSpock
           assert_equal 2, ir.children.length
           assert_equal :rspock_binary_statement, ir.children[0].type
           assert_equal :rspock_interaction, ir.children[1].type
+        end
+
+        test "#to_rspock_node converts raises() to :rspock_raises" do
+          node = @transformer.build_ast('raises EmptyStackError')
+          @block << node
+
+          ir = @block.to_rspock_node
+          assert_equal :rspock_then, ir.type
+          assert_equal 1, ir.children.length
+          assert_equal :rspock_raises, ir.children[0].type
+        end
+
+        test "#to_rspock_node raises on multiple raises() conditions" do
+          @block << @transformer.build_ast('raises EmptyStackError')
+          @block << @transformer.build_ast('raises AnotherError')
+
+          assert_raises BlockError do
+            @block.to_rspock_node
+          end
         end
 
         test "#to_rspock_node with multiple interactions has correct indices" do


### PR DESCRIPTION
## Summary
* Add Spock-style raises exception conditions for Then blocks: raises ExceptionClass wraps the preceding When block in an exception assertion, and e = raises ExceptionClass captures the exception for further property assertions.
* Rename interaction outcome nodes from rspock_returns / rspock_raises to rspock_stub_returns / rspock_stub_raises to free up the clean rspock_raises type for exception conditions.
* Add documentation (README section + CHANGELOG entry) and comprehensive test coverage including data-driven Where block integration.

## Test plan
* [x] Unit tests for StatementParser covering raises detection (direct, assigned, and negative cases)
* [x] Unit tests for ThenBlock validation (at most one raises per block)
* [x] Unit tests for ExpectBlock validation (raises disallowed)
* [x] Interaction parser tests updated for renamed stub_* node types
* [x] Integration tests in example_rspock_test.rb: basic raises, capture with property assertion, and data-driven raises with Where block
* [x] All existing tests pass (no regressions from node rename)